### PR TITLE
Update disk-image-create path

### DIFF
--- a/diskimage-create/README.rst
+++ b/diskimage-create/README.rst
@@ -41,6 +41,11 @@ or it can be overridden by setting the following environment variables:
     DIB_REPO_PATH = /<some directory>/diskimage-builder
     DIB_ELEMENTS = /<some directory>/diskimage-builder/elements
 
+diskimage-create has been moved in diskimage-builder repo:
+
+.. code-block:: bash
+
+    ln -s ${DIB_REPO_PATH}/diskimage_builder/lib/disk-image-create ${DIB_REPO_PATH}/bin/
 
 The following packages are required on each platform:
 


### PR DESCRIPTION
disk-image-create has been moved to diskimage_builder/lib:
https://tinyurl.com/j4s9urkw

I needed to link it when I was building stable/victoria amphora images but it is also possible that I messed something up along the way. If that's the case, please ignore this PR ;)