### PR TITLE
ALLOWS TO LIST THE DELETED INSTANCES

### DIFF
--- a/octavia/api/v2/controllers/amphora.py
+++ b/octavia/api/v2/controllers/amphora.py
@@ -50,7 +50,7 @@ class AmphoraController(base.BaseController):
         """Gets a single amphora's details."""
         context = pecan_request.context.get('octavia_context')
         with context.session.begin():
-            db_amp = self._get_db_amp(context.session, id, show_deleted=False)
+            db_amp = self._get_db_amp(context.session, id, show_deleted=CONF.api_settings.show_deleted)
 
         self._auth_validate_action(context, context.project_id,
                                    constants.RBAC_GET_ONE)
@@ -73,7 +73,7 @@ class AmphoraController(base.BaseController):
 
         with context.session.begin():
             db_amp, links = self.repositories.amphora.get_all_API_list(
-                context.session, show_deleted=False,
+                context.session, show_deleted=CONF.api_settings.show_deleted,
                 pagination_helper=pcontext.get(constants.PAGINATION_HELPER))
         result = self._convert_db_to_type(
             db_amp, [amp_types.AmphoraResponse])

--- a/octavia/common/config.py
+++ b/octavia/common/config.py
@@ -136,6 +136,8 @@ api_opts = [
                          lib_consts.ALPN_PROTOCOL_HTTP_1_0],
                 help=_('List of ALPN protocols to use for new TLS-enabled '
                        'pools.')),
+    cfg.BoolOpt('show_deleted', default=False,
+                help=_("Allows to list the deleted instances")),
 ]
 
 # Options only used by the amphora agent


### PR DESCRIPTION
Just as Nova has the ability to list instances that have been deleted, I propose this change in order to enable or disable the listing of deleted amphoras by configuring it in octavia.conf
[api_settings]
show_deleted=True/False